### PR TITLE
Fix relative module resolution for config files

### DIFF
--- a/packages/config/src/evalConfig.ts
+++ b/packages/config/src/evalConfig.ts
@@ -35,7 +35,7 @@ export function evalConfig(
     presets: [preset],
   });
 
-  let result = requireString(code);
+  let result = requireString(code, configFile);
   if (result.default != null) {
     result = result.default;
   }


### PR DESCRIPTION
I was receiving a `MODULE_NOT_FOUND` error with my config since it references relative modules. This sets `configFile` as the `filename` argument to `require-from-string` so relative modules can be resolved properly